### PR TITLE
Allow using a custom listen port

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,6 +15,9 @@ It needs 4 environment variables:
 - `RECEIVER` - Phone number of receiver (optional parameter, representing default receiver)
 - `SENDER` - Phone number managed by Twilio (friendly name)
 
+By default promtotwilio listens on port 9090. You can select a different port
+by setting the `PORT` environment variable.
+
 You can see a basic launch inside the Makefile.
 
 ## API

--- a/main.go
+++ b/main.go
@@ -2,6 +2,7 @@ package main
 
 import (
 	"os"
+	"fmt"
 
 	log "github.com/sirupsen/logrus"
 	"github.com/valyala/fasthttp"
@@ -12,14 +13,21 @@ type options struct {
 	AuthToken  string
 	Receiver   string
 	Sender     string
+	Port       string
 }
 
 func main() {
+	port := os.Getenv("PORT")
+	if port == "" {
+		port = "9090"
+	}
+
 	opts := options{
 		AccountSid: os.Getenv("SID"),
 		AuthToken:  os.Getenv("TOKEN"),
 		Receiver:   os.Getenv("RECEIVER"),
 		Sender:     os.Getenv("SENDER"),
+		Port:       port,
 	}
 
 	if opts.AccountSid == "" || opts.AuthToken == "" || opts.Sender == "" {
@@ -27,7 +35,7 @@ func main() {
 	}
 
 	o := NewMOptionsWithHandler(&opts)
-	err := fasthttp.ListenAndServe(":9090", o.HandleFastHTTP)
+	err := fasthttp.ListenAndServe(fmt.Sprintf(":%s", port), o.HandleFastHTTP)
 	if err != nil {
 		log.Fatal("ListenAndServe: ", err)
 	}


### PR DESCRIPTION
In our case Prometheus itself is listening on port 9090, so the default port could not be used. This PR adds support for customizing the port while retaining the backwards compatibility.

This is my first ever contribution in Go, so please point me in the right direction if the way this was implemented was not optimal.