### PR TITLE
Support sending alerts to multiple SMS numbers

### DIFF
--- a/options_with_handler.go
+++ b/options_with_handler.go
@@ -68,7 +68,19 @@ func (m OptionsWithHandler) sendRequest(ctx *fasthttp.RequestCtx) {
 
 			if status == "firing" {
 				_, err := jsonparser.ArrayEach(body, func(alert []byte, dataType jsonparser.ValueType, offset int, err error) {
-					go sendMessage(sendOptions, alert)
+
+					receivers := strings.Split(sendOptions.Receiver, ",")
+					for _, r := range receivers {
+						so := new(options)
+						so.AccountSid = sendOptions.AccountSid
+						so.AuthToken  = sendOptions.AuthToken
+						so.Sender     = sendOptions.Sender
+						so.Receiver   = r
+						log.Infof("Receiver: %v", so.Receiver)
+						go sendMessage(so, alert)
+					}
+
+
 				}, "alerts")
 				if err != nil {
 					log.Warnf("Error parsing json: %v", err)


### PR DESCRIPTION
This is done by creating a new struct based on sendOptions but with identical data. This is required to avoid the same data structure in memory getting modified in the for loop before SMS messages are sent - end result of which would be sending all the SMS messages to the last receiver on the list.