### PR TITLE
chore: upgrade Go to 1.26

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -27,7 +27,7 @@ jobs:
       - name: Set up Go
         uses: actions/setup-go@v6
         with:
-          go-version: "1.23"
+          go-version: "1.26"
 
       - name: Run tests with coverage
         run: make coverage
@@ -45,7 +45,7 @@ jobs:
       - name: Set up Go
         uses: actions/setup-go@v6
         with:
-          go-version: "1.23"
+          go-version: "1.26"
 
       - name: Run golangci-lint
         uses: golangci/golangci-lint-action@v9
@@ -62,7 +62,7 @@ jobs:
       - name: Set up Go
         uses: actions/setup-go@v6
         with:
-          go-version: "1.23"
+          go-version: "1.26"
 
       - name: Build
         run: make build
@@ -97,7 +97,7 @@ jobs:
       - name: Set up Go
         uses: actions/setup-go@v6
         with:
-          go-version: "1.23"
+          go-version: "1.26"
 
       - name: Validate version format
         run: |

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -3,7 +3,7 @@
 ## Development Setup
 
 1. Clone the repository
-2. Ensure Go 1.23+ is installed
+2. Ensure Go 1.26+ is installed
 3. Run `make check` to verify everything works
 
 ## Code Style

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM golang:1.25-alpine AS builder
+FROM golang:1.26-alpine AS builder
 
 RUN mkdir /user && \
     echo 'nobody:x:65534:65534:nobody:/:' > /user/passwd && \

--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 # promtotwilio
 
 [![License: MIT](https://img.shields.io/badge/License-MIT-blue.svg)](LICENSE.txt)
-[![Go](https://img.shields.io/badge/Go-1.23+-00ADD8?logo=go&logoColor=white)](https://go.dev)
+[![Go](https://img.shields.io/badge/Go-1.26+-00ADD8?logo=go&logoColor=white)](https://go.dev)
 
 **Send Prometheus alerts as SMS via Twilio.** Get notified on your phone when things go wrong.
 
@@ -229,7 +229,7 @@ This project uses **only Go's standard library** — no external dependencies. T
 
 ### Prerequisites
 
-- Go 1.23+
+- Go 1.26+
 - Docker (optional)
 
 ### Commands

--- a/go.mod
+++ b/go.mod
@@ -1,3 +1,3 @@
 module github.com/swatto/promtotwilio
 
-go 1.23
+go 1.26

--- a/internal/handler/handler.go
+++ b/internal/handler/handler.go
@@ -158,9 +158,8 @@ func (h *Handler) SendRequest(w http.ResponseWriter, r *http.Request) {
 		for i := range payload.Alerts {
 			alert := &payload.Alerts[i]
 			for _, receiver := range receivers {
-				wg.Add(1)
-				go func(rcv string, a *Alert) {
-					defer wg.Done()
+				rcv, a := receiver, alert
+				wg.Go(func() {
 					sendErr := h.sendMessage(rcv, a, status)
 					mu.Lock()
 					defer mu.Unlock()
@@ -170,7 +169,7 @@ func (h *Handler) SendRequest(w http.ResponseWriter, r *http.Request) {
 					} else {
 						sent++
 					}
-				}(receiver, alert)
+				})
 			}
 		}
 

--- a/internal/handler/twilio_test.go
+++ b/internal/handler/twilio_test.go
@@ -155,6 +155,7 @@ func TestNew_WithAuthToken(t *testing.T) {
 	// Verify handler was created
 	if h == nil {
 		t.Fatal("expected handler, got nil")
+		return
 	}
 	if h.Config != cfg {
 		t.Error("expected config to be set")
@@ -177,6 +178,7 @@ func TestNew_WithAPIKey(t *testing.T) {
 	// Verify handler was created
 	if h == nil {
 		t.Fatal("expected handler, got nil")
+		return
 	}
 	if h.Config != cfg {
 		t.Error("expected config to be set")

--- a/test/mock-exporter/Dockerfile
+++ b/test/mock-exporter/Dockerfile
@@ -1,4 +1,4 @@
-FROM golang:1.24-alpine AS builder
+FROM golang:1.26-alpine AS builder
 
 WORKDIR /app
 COPY go.mod ./

--- a/test/mock-exporter/go.mod
+++ b/test/mock-exporter/go.mod
@@ -1,3 +1,3 @@
 module mock-exporter
 
-go 1.24
+go 1.26

--- a/test/mock-twilio/Dockerfile
+++ b/test/mock-twilio/Dockerfile
@@ -1,4 +1,4 @@
-FROM golang:1.25-alpine AS builder
+FROM golang:1.26-alpine AS builder
 
 WORKDIR /app
 COPY go.mod main.go ./

--- a/test/mock-twilio/go.mod
+++ b/test/mock-twilio/go.mod
@@ -1,3 +1,3 @@
 module mock-twilio
 
-go 1.23
+go 1.26


### PR DESCRIPTION
## Summary

- Upgrade Go version from 1.23 to 1.26 across all go.mod files, Dockerfiles, CI, and docs
- Use `sync.WaitGroup.Go()` (Go 1.25+) to simplify goroutine dispatch in the alert handler
- Fix staticcheck SA5011 warnings by adding explicit `return` after `t.Fatal` nil-checks

## Notes

- Binary size increases ~6-12% due to Go runtime improvements (Green Tea GC, Swiss Tables maps, heap randomization) — this is expected for any 1.23→1.26 upgrade
- No new dependencies added; `go.mod` remains at 3 lines with zero external deps

## Test plan

- [x] `go build ./...` passes
- [x] `go test ./...` passes
- [x] `golangci-lint run` passes
- [x] Binary size verified against v1.8.0


Made with [Cursor](https://cursor.com)